### PR TITLE
Adding alias to prevent 404 error

### DIFF
--- a/modules/ROOT/pages/bloom-installation/advanced-installation.adoc
+++ b/modules/ROOT/pages/bloom-installation/advanced-installation.adoc
@@ -1,4 +1,5 @@
 :description: This section describes advanced installation and configuration of Neo4j Bloom.
+:page-aliases: /advanced-installation/
 
 [[advanced-installation]]
 = Advanced installation and configuration


### PR DESCRIPTION
Apparently the content was rearranged, causing a 404 error coming from the links featured on the Neo4j Security page (https://neo4j.com/docs/security-docs/).