### PR TITLE
DOCOPS-164 Accessibility: alt text for Bloom overview, architecture, and action icons

### DIFF
--- a/modules/ROOT/pages/about-bloom.adoc
+++ b/modules/ROOT/pages/about-bloom.adoc
@@ -12,7 +12,7 @@ This chapter introduces the main features and components of Neo4j Bloom .
 
 The core set of Bloom features can be visualized as shown in this picture.
 
-image::image20.png[width=800]
+image::image20.png["The six core Bloom features arranged around the Neo4j Bloom logo: Perspective, Visualization, Search, Editing, Inspection, and Exploration",width=800]
 
 * *Perspective* - the lens through which you view graph data, can be customized for different business purposes.
 See xref::/bloom-perspectives/bloom-perspectives.adoc[] or watch the link:https://www.youtube.com/watch?v=GV3WCEsHRYI&list=PL9Hl4pk2FsvWqH11v_WXVNIgb4iHjqHgs[Bloom video series] for more details on this feature.

--- a/modules/ROOT/pages/bloom-appendix/bloom-appendix.adoc
+++ b/modules/ROOT/pages/bloom-appendix/bloom-appendix.adoc
@@ -19,7 +19,7 @@ A summary of the actions and associated keyboard shortcuts are below.
 | Shortcut
 | Typed in search bar
 
-| image:icon-magnifying-glass.png[width=25]
+| image:icon-magnifying-glass.png["",width=25]
 | Inspect
 | Opens the detail view of a selected node, showing all its properties and labels
 | _Mac_: kbd:[⌘+I]
@@ -27,7 +27,7 @@ A summary of the actions and associated keyboard shortcuts are below.
 _Windows_: kbd:[Ctrl+I]
 | {cross-mark}
 
-| image:select-related-nodes.png[width=25]
+| image:select-related-nodes.png["",width=25]
 | Select related nodes
 | Selects all nodes that can be connected to selected node
 | _Mac_: kbd:kbd:[⌘+⇧+R]
@@ -39,7 +39,7 @@ _Windows_: kbd:[Ctrl+⇧+R]
 
 // _Windows_: kbd:[Ctrl+Alt+E]   | {cross-mark}
 
-| image:icon-invert.png[width=25]
+| image:icon-invert.png["",width=25]
 | Invert Selection
 | Inverts the current selection
 | _Mac_: kbd:[⌘+⌥+A]
@@ -47,7 +47,7 @@ _Windows_: kbd:[Ctrl+⇧+R]
 _Windows_: kbd:[Ctrl+Alt+A]
 | {check-mark}
 
-| image:icon-fit-selection.png[width=25]
+| image:icon-fit-selection.png["",width=25]
 | Fit to selection
 | Zooms in and centers the selection on the scene
 | _Mac_: kbd:[⌘+F]
@@ -55,27 +55,27 @@ _Windows_: kbd:[Ctrl+Alt+A]
 _Windows_: kbd:[Ctrl+F]
 | {check-mark}
 
-| image:icon-expand-reveal.png[width=25]  | Expand
+| image:icon-expand-reveal.png["",width=25]  | Expand
 | Expands all the neighbours of the selected nodes
 | _Mac_: kbd:[⌘+E]
 
 _Windows_: kbd:[Ctrl+E]
 | {check-mark}
 
-| image:icon-expand-reveal.png[width=25]
+| image:icon-expand-reveal.png["",width=25]
 | Reveal
 | List/Detail view specific action.
 Reveals all the selected nodes or relationships on the scene.
 |
 | {cross-mark}
 
-| image:icon-path.png[width=25]
+| image:icon-path.png["",width=25]
 | Path
 | Shows the shortest path between two selected nodes
 |
 | {cross-mark}
 
-| image:icon-dismiss.png[width=25]
+| image:icon-dismiss.png["",width=25]
 | Dismiss
 | Hides all selected nodes and relationships
 | _Mac_: kbd:[⌘+H]
@@ -83,7 +83,7 @@ Reveals all the selected nodes or relationships on the scene.
 _Windows_: kbd:[Ctrl+H]
 | {check-mark}
 
-| image:icon-dismiss.png[width=25]
+| image:icon-dismiss.png["",width=25]
 | Dismiss other nodes
 | Hides everything that is not selected
 | _Mac_: kbd:[⌘+⇧+H]
@@ -91,21 +91,21 @@ _Windows_: kbd:[Ctrl+H]
 _Windows_: kbd:[Ctrl+⇧+H]
 | {check-mark}
 
-| image:icon-add.png[width=25]
+| image:icon-add.png["",width=25]
 | Create relationship
 | Allows the creation of relationship between two selected nodes.
 The direction is set in the sequence in which the two nodes are clicked.
 |
 | {cross-mark}
 
-| image:icon-add.png[width=25]
+| image:icon-add.png["",width=25]
 | Create node
 | Allows the creation of a node in a specified category.
 The newly created node will inherit all the labels that category has.
 |
 | {cross-mark}
 
-| image:icon-duplicate.png[width=25]
+| image:icon-duplicate.png["",width=25]
 | Duplicate
 | Duplicates a selected node with all the properties it has.
 The newly duplicated node is always selected and has no relationships to other nodes.
@@ -114,7 +114,7 @@ The newly duplicated node is always selected and has no relationships to other n
 _Windows_: kbd:[Ctrl+D]
 | {cross-mark}
 
-| image:icon-clear.png[width=25]
+| image:icon-clear.png["",width=25]
 | Clear Scene
 | Clears the whole scene and collapses the list view
 | _Mac_: kbd:[⌘+⌫]
@@ -122,13 +122,13 @@ _Windows_: kbd:[Ctrl+D]
 _Windows_: kbd:[Ctrl+⌫]
 | {cross-mark}
 
-| image:refresh-data.png[width=25]
+| image:refresh-data.png["",width=25]
 | Refresh Data
 | Refreshes the data in the Scene
 |
 | {cross-mark}
 
-| image:dismiss-single-nodes.png[width=25]
+| image:dismiss-single-nodes.png["",width=25]
 | Dismiss single nodes
 | Hides all nodes that have no relationships to other nodes in the Scene
 | _Mac_: kbd:[⌘+⇧+S]
@@ -136,19 +136,19 @@ _Windows_: kbd:[Ctrl+⌫]
 _Windows_: kbd:[Ctrl+⇧+S]
 | {cross-mark}
 
-| image:icon-undo.png[width=25]
+| image:icon-undo.png["",width=25]
 | Undo
 |
 |
 | {check-mark}
 
-| image:icon-redo.png[width=25]
+| image:icon-redo.png["",width=25]
 | Redo
 |
 |
 | {check-mark}
 
-| image:icon-jumpto.png[width=25]
+| image:icon-jumpto.png["",width=25]
 | Jump to node/relationship
 | Zooms in and centers the desired node or relationship on the scene
 |

--- a/modules/ROOT/pages/bloom-installation/advanced-installation.adoc
+++ b/modules/ROOT/pages/bloom-installation/advanced-installation.adoc
@@ -12,7 +12,7 @@ In this case, the Bloom client UI (provided as a separate package) is hosted by 
 The Bloom client connects to the Neo4j database, either via serving a json file containing the Neo4j database discovery URL, or by using a _connectURL_ parameter.
 This is described in detail further on.
 
-image::web-server-hosted-bloom-client.svg[width=550,align="center"]
+image::web-server-hosted-bloom-client.svg["Architecture for a web-server-hosted Bloom client: a user runs the Bloom client in a web browser, which (1) connects over HTTP to a separate web server hosting the Bloom client UI assets, (2) receives the client UI and a database discovery URL, then (3) connects over BOLT to the BOLT server of the Neo4j server, which also contains the Bloom Server plug-in and the Neo4j DBMS",width=550,align="center"]
 
 For scenarios where you want to host Bloom client on a web server separate from the Neo4j database server, the Bloom client UI is available as a web asset bundle.
 The Bloom plugin is still required to be installed on the Neo4j database server, see xref:bloom-installation/installation-activation.adoc#installing-server-plugin[Installing server plugin] for more information.
@@ -379,7 +379,7 @@ For this to be possible, _server-side routing_ needs to be enabled, please see l
 
 For more information about Neo4j clusters, see link:{operations-manual-base-uri}current/clustering/[Operations Manual -> Clustering].
 
-image::bloom-in-a-neo4j-cluster.svg[width=700,align="center"]
+image::bloom-in-a-neo4j-cluster.svg["Architecture for Bloom in a Neo4j cluster: a user runs the Bloom client in a web browser and (1) connects over HTTP to the Neo4j web server on a database primary (or a GDS-enabled server), (2) loads the client UI assets from the Bloom Server plug-in, then (3) connects to the cluster using BOLT+Routing; the cluster is drawn as database primaries with a leader plus database secondaries, each running a BOLT server and Bloom Server plug-in",width=700,align="center"]
 
 [[bloom-telemetry]]
 == Settings for Product Analytics

--- a/modules/ROOT/pages/bloom-quick-start.adoc
+++ b/modules/ROOT/pages/bloom-quick-start.adoc
@@ -22,7 +22,7 @@ See xref::/bloom-perspectives/database-scans.adoc[Database scans] for more infor
 Graph exploration begins by searching for interesting parts of the graph.
 
 [.shadow]
-image::bloom-overview.png[width=800]
+image::bloom-overview.png["Annotated overview of the Neo4j Bloom interface over an example graph, with callouts labelling the main areas: the connection bar, the perspective drawer and designer, the search bar, the filter and slicer tools, the selection tools, scene mode, the legend panel of node categories, export and settings, the map controls, the layout toggle, and the card list",width=800]
 
 Note that items marked with * are only available with the Bloom plugin.
 {nbsp} +

--- a/modules/ROOT/pages/bloom-visual-tour/bloom-overview.adoc
+++ b/modules/ROOT/pages/bloom-visual-tour/bloom-overview.adoc
@@ -4,7 +4,7 @@
 = Overview
 
 [.shadow]
-image::bloom-overview.png[width=800]
+image::bloom-overview.png["Annotated overview of the Neo4j Bloom interface over an example graph, with callouts labelling the main areas: the connection bar, the perspective drawer and designer, the search bar, the filter and slicer tools, the selection tools, scene mode, the legend panel of node categories, export and settings, the map controls, the layout toggle, and the card list",width=800]
 
 Note that items marked with * are only available with the Bloom plugin.
 


### PR DESCRIPTION
## What

First alt-text batch for **docs-bloom** (WCAG 1.1.1), part of the rollout (DOCOPS-164, under DOCOPS-154). 19 images across the overview, installation, and appendix pages.

### Described (informative)
| Image | Page(s) | Alt (summary) |
|---|---|---|
| image20.png | about-bloom | six core Bloom features around the logo (Perspective, Visualization, Search, Editing, Inspection, Exploration) |
| bloom-overview.png | bloom-overview + bloom-quick-start (**shared**) | annotated overview of the Bloom UI with its main areas labelled |
| web-server-hosted-bloom-client.svg | advanced-installation | architecture: browser client → separate web server (HTTP) → Neo4j server over BOLT |
| bloom-in-a-neo4j-cluster.svg | advanced-installation | architecture: browser client → cluster (primaries/leader + secondaries) over BOLT+Routing |

### Decorative (`alt=""`)
The **15 icons** in the _Default actions_ appendix table (`icon-*`, plus `select-related-nodes`, `refresh-data`, `dismiss-single-nodes`) are marked decorative: each sits in the table next to its **Action name and Description**, so alt text would be redundant double-announcement.

## Please double-check
- **bloom-overview.png** — dense annotated UI; I summarised the labelled regions rather than transcribing every callout. Worth a look.
- The two **architecture SVGs** — I described the numbered connection flow; confirm it matches the steps in the page text.
- The **decorative calls** on the appendix icons — confirm you're happy the adjacent table columns carry the meaning.

## Verification
`npm run verify:preview` exits 0 with zero warn/error/fatal in `build/log/log.json`. Rendered HTML confirmed: descriptions appear in full, and the decorative icons render as `alt=""` (not the filename). Only `.adoc` files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)