### PR TITLE
DOCOPS-176 Add page-tabs attributes to antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -6,6 +6,8 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: tools@
+    page-tabs-index: 10
     neo4j-buildnumber: '5.13'
     docs-version: '2.35'
 


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `antora.yml`:

```yaml
asciidoc:
  attributes:
    page-tabs: tools@
    page-tabs-index: 10
```

Places this docset in the `tools` tab of the aggregated tabbed navigation, at the
position matching its order in the Docs menu on neo4j.com/docs. The value is
soft-set with a trailing `@` so it can be overridden.

Set in `antora.yml` rather than the publish playbook so the attributes apply to every
build of this component, independent of which playbook generates the HTML. This is
safe here because this docset publishes a single version.
